### PR TITLE
MallocDeadPage: avoid out-of-bound heap data for overrun check

### DIFF
--- a/MakeCommon
+++ b/MakeCommon
@@ -90,109 +90,109 @@ run: Test1 Test2 Test3 Test4 Test5 Test6 Test7 Test8 Test9
 Test1: TestPatch
 	echo "-------------------------------------------"
 	echo "Test1 symbol patching"
-	/bin/csh -c "setenv AT_CONFIG_FILE $(TESTSRC)/TestPatch.ini; \
-		setenv LD_LIBRARY_PATH $(LIBPATH); \
-		setenv LD_PRELOAD $(LIBACCUTRAK); \
+	/bin/bash -c "export AT_CONFIG_FILE=$(TESTSRC)/TestPatch.ini; \
+		export LD_LIBRARY_PATH=$(LIBPATH); \
+		export LD_PRELOAD=$(LIBACCUTRAK); \
 		./TestPatch"
 
 Test2: TestOverrun
 	echo "-------------------------------------------"
 	echo "Test2 over run checking, should seg fault"
-	/bin/csh -c "setenv AT_CONFIG_FILE $(TESTSRC)/TestPatch.ini; \
-		setenv LD_LIBRARY_PATH $(LIBPATH); \
-		setenv LD_PRELOAD $(LIBACCUTRAK); \
+	/bin/bash -c "export AT_CONFIG_FILE=$(TESTSRC)/TestPatch.ini; \
+		export LD_LIBRARY_PATH=$(LIBPATH); \
+		export LD_PRELOAD=$(LIBACCUTRAK); \
 		./TestOverrun"
 
 Test3: TestUnderrun
 	echo "-------------------------------------------"
 	echo "Test3 under run checking, should seg fault"
-	/bin/csh -c "setenv AT_CONFIG_FILE $(TESTSRC)/TestUnderrun.ini; \
-		setenv LD_LIBRARY_PATH $(LIBPATH); \
-		setenv LD_PRELOAD $(LIBACCUTRAK); \
+	/bin/bash -c "export AT_CONFIG_FILE=$(TESTSRC)/TestUnderrun.ini; \
+		export LD_LIBRARY_PATH=$(LIBPATH); \
+		export LD_PRELOAD=$(LIBACCUTRAK); \
 		./TestUnderrun"
 
 Test4: TestPatchDSO libfoo.${LIBSUFFIX}
 	echo "-------------------------------------------"
 	echo "Test4 DSO symbol patching"
-	/bin/csh -c "setenv AT_CONFIG_FILE $(TESTSRC)/TestPatchDSO.ini; \
-		setenv LD_LIBRARY_PATH ./:$(LIBPATH); \
-		setenv LIBPATH ./:$(LIBPATH); 
-		setenv LD_PRELOAD $(LIBACCUTRAK); \
+	/bin/bash -c "export AT_CONFIG_FILE=$(TESTSRC)/TestPatchDSO.ini; \
+		export LD_LIBRARY_PATH=./:$(LIBPATH); \
+		export LIBPATH=./:$(LIBPATH); \
+		export LD_PRELOAD=$(LIBACCUTRAK); \
 		./TestPatchDSO"
 
 Test5: TestRealloc
 	echo "-------------------------------------------"
 	echo "Test5 realloc"
-	/bin/csh -c "setenv AT_CONFIG_FILE $(TESTSRC)/TestPatch.ini; \
-		setenv LD_LIBRARY_PATH $(LIBPATH); \
-		setenv LD_PRELOAD $(LIBACCUTRAK); \
+	/bin/bash -c "export AT_CONFIG_FILE=$(TESTSRC)/TestPatch.ini; \
+		export LD_LIBRARY_PATH=$(LIBPATH); \
+		export LD_PRELOAD=$(LIBACCUTRAK); \
 		./TestRealloc"
 
 Test6: TestPreLoad
 	echo "-------------------------------------------"
 	echo "Test6 preload AccuTrak (only if OS support PRELOAD)"
-	/bin/csh -c "setenv AT_CONFIG_FILE $(TESTSRC)/TestPatchDSO.ini; \
-		setenv LD_PRELOAD $(LIBACCUTRAK); \
-		setenv LD_LIBRARY_PATH ./:$(LIBPATH); \
+	/bin/bash -c "export AT_CONFIG_FILE=$(TESTSRC)/TestPatchDSO.ini; \
+		export LD_PRELOAD=$(LIBACCUTRAK); \
+		export LD_LIBRARY_PATH=./:$(LIBPATH); \
 		./TestPreLoad"
 
 Test7: TestNew
 	echo "-------------------------------------------"
 	echo "Test7 patch operator new, over run checking, should seg fault"
-	/bin/csh -c "setenv AT_CONFIG_FILE $(TESTSRC)/TestPatch.ini; \
-		setenv LD_LIBRARY_PATH $(LIBPATH); \
-		setenv LD_PRELOAD $(LIBACCUTRAK); \
+	/bin/bash -c "export AT_CONFIG_FILE=$(TESTSRC)/TestPatch.ini; \
+		export LD_LIBRARY_PATH=$(LIBPATH); \
+		export LD_PRELOAD=$(LIBACCUTRAK); \
 		./TestNew"
 
 Test8: TestPrivateHeap
 	echo "-------------------------------------------"
 	echo "Test8 Allocate memory from private heap in libfoo.so"
-	/bin/csh -c "setenv AT_CONFIG_FILE $(TESTSRC)/TestPrivateHeap.ini; \
-		setenv LD_LIBRARY_PATH ./:$(LIBPATH); \
-		setenv LD_PRELOAD $(LIBACCUTRAK); \
+	/bin/bash -c "export AT_CONFIG_FILE=$(TESTSRC)/TestPrivateHeap.ini; \
+		export LD_LIBRARY_PATH=./:$(LIBPATH); \
+		export LD_PRELOAD=$(LIBACCUTRAK); \
 		./TestPrivateHeap"
 
 Test9: TestRecord libfoo.${LIBSUFFIX}
 	echo "-------------------------------------------"
 	echo "Test9 Record all"
-	/bin/csh -c "setenv AT_CONFIG_FILE $(TESTSRC)/TestRecord.ini; \
-		setenv LD_LIBRARY_PATH ./:$(LIBPATH); \
-		setenv LIBPATH ./:$(LIBPATH); \
-		setenv LD_PRELOAD $(LIBACCUTRAK); \
+	/bin/bash -c "export AT_CONFIG_FILE=$(TESTSRC)/TestRecord.ini; \
+		export LD_LIBRARY_PATH=./:$(LIBPATH); \
+		export LIBPATH=./:$(LIBPATH); \
+		export LD_PRELOAD=$(LIBACCUTRAK); \
 		./TestRecord"
 
 Test10: TestSize
 	echo "-------------------------------------------"
 	echo "Test10 Track blocks within size range"
-	/bin/csh -c "setenv AT_CONFIG_FILE $(TESTSRC)/TestSize.ini; \
-		setenv LD_LIBRARY_PATH ./:$(LIBPATH); \
-		setenv LIBPATH ./:$(LIBPATH); \
-		setenv LD_PRELOAD $(LIBACCUTRAK); \
+	/bin/bash -c "export AT_CONFIG_FILE=$(TESTSRC)/TestSize.ini; \
+		export LD_LIBRARY_PATH=./:$(LIBPATH); \
+		export LIBPATH=./:$(LIBPATH); \
+		export LD_PRELOAD=$(LIBACCUTRAK); \
 		./TestSize"
 
 Test11: TestAccessFree
 	echo "-------------------------------------------"
 	echo "Test11 Touch freed block and we should seg fault"
-	/bin/csh -c "setenv AT_CONFIG_FILE $(TESTSRC)/TestAccessFree.ini; \
-		setenv LD_LIBRARY_PATH ./:$(LIBPATH); \
-		setenv LIBPATH ./:$(LIBPATH); \
-		setenv LD_PRELOAD $(LIBACCUTRAK); \
+	/bin/bash -c "export AT_CONFIG_FILE=$(TESTSRC)/TestAccessFree.ini; \
+		export LD_LIBRARY_PATH=./:$(LIBPATH); \
+		export LIBPATH=./:$(LIBPATH); \
+		export LD_PRELOAD=$(LIBACCUTRAK); \
 		./TestAccessFree"
 
 Test12: TestDoubleFree
 	echo "-------------------------------------------"
 	echo "Test12 Free a block twice and we should be stopped by AccuTrak"
-	/bin/csh -c "setenv AT_CONFIG_FILE $(TESTSRC)/TestDoubleFree.ini; \
-		setenv LD_LIBRARY_PATH ./:$(LIBPATH); \
-		setenv LIBPATH ./:$(LIBPATH); \
-		setenv LD_PRELOAD $(LIBACCUTRAK); \
+	/bin/bash -c "export AT_CONFIG_FILE=$(TESTSRC)/TestDoubleFree.ini; \
+		export LD_LIBRARY_PATH=./:$(LIBPATH); \
+		export LIBPATH=./:$(LIBPATH); \
+		export LD_PRELOAD=$(LIBACCUTRAK); \
 		./TestDoubleFree"
 
 Test13: TestBenchmark
 	echo "-------------------------------------------"
 	echo "Test13 Allocate memory in multiple threads in deadpage mode"
-	/bin/csh -c "setenv AT_CONFIG_FILE $(TESTSRC)/TestBenchmark.ini; \
-		setenv LD_LIBRARY_PATH ./:$(LIBPATH); \
-		setenv LIBPATH ./:$(LIBPATH); \
-		setenv LD_PRELOAD $(LIBACCUTRAK); \
+	/bin/bash -c "export AT_CONFIG_FILE=$(TESTSRC)/TestBenchmark.ini; \
+		export LD_LIBRARY_PATH=./:$(LIBPATH); \
+		export LIBPATH=./:$(LIBPATH); \
+		export LD_PRELOAD=$(LIBACCUTRAK); \
 		/usr/bin/time -p ./TestBenchmark"

--- a/src/MallocDeadPage.cpp
+++ b/src/MallocDeadPage.cpp
@@ -443,6 +443,7 @@ void*  MallocBlockWithDeadPage(size_t iSize)
 	bool   lbCheckUnderrun = gPatchMgr->CheckUnderrun();
 
 	size_t Remainder;
+	size_t lRequestSize = iSize;
 	// Adjust the requested size
 	//
 	// Alignment, for overrun check only
@@ -544,7 +545,7 @@ void*  MallocBlockWithDeadPage(size_t iSize)
 	// Now, the header pointer should point to either in-page or out-page header structure
 	lpHeader->mRawBlockAddr = lpRawBlock;
 	lpHeader->p.mUserAddr = lpUserAddr;
-	lpHeader->mUserSize = iSize;
+	lpHeader->mUserSize = lRequestSize;
 	SET_SIGNATURE(lpHeader);
 
 	OUTPUT_MSG2(AT_ALL, "MallocBlockWithDeadPage allocates %d bytes at 0x%lx successfully\n", iSize, lpUserAddr);

--- a/src/MallocDeadPage.cpp
+++ b/src/MallocDeadPage.cpp
@@ -462,6 +462,23 @@ void*  MallocBlockWithDeadPage(size_t iSize)
 	{
 		lRealSize += lPageSize - Remainder;
 	}
+	// For overrun check, if the request size is close to page size or its multiple,
+	//   adjust request size so that more space is allocated for in-bound heap data;
+	//   the downside is that padding bytes are left at the bottome of user space
+	// The underrun check can't adjust because it is necessary that inbound heap data
+	//   are laid out in the same page as the user starting address
+	if(!lbCheckUnderrun) {
+		Remainder = lRealSize - lPageSize - iSize;
+		if (Remainder < sizeof(BlockWithDeadPageHeader)) {
+			lRealSize += lPageSize;
+			// For overrun check, ensure the alignment
+			iSize += Remainder;
+			if(lAlignment > 0)
+				iSize += lAlignment;
+			else
+				iSize += sizeof(size_t);
+		}
+	}
 
 	// At this point, lRealSize must be multiple of system page size
 	// The returned block should have dead page set properly alreday.
@@ -487,6 +504,13 @@ void*  MallocBlockWithDeadPage(size_t iSize)
 			// which is also on the immediate page boundary of user space
 			lpHeader = (BlockWithDeadPageHeader*)lpRawBlock;
 			lbUseEmbeddedHeader = true;
+			// TODO
+			// If extra space is allocated for user, pad them with special bytes
+
+		} else {
+			// We should always have enough space for inbound heap data
+			fprintf(stderr, "Internal error: no space for inbound Deadpage heap data\n");
+			abort();
 		}
 	}
 	// Otherwise check underrun


### PR DESCRIPTION
The current implementation has a performance issue when the size of the tracked memory blocks are of one or or multiple system page(s), or sufficiently close to that. In which case, the heap data is stored in a global list instead of being embedded  in the allocated memory block.
The fix is to add one additional page in such scenario to accommodate the heap data. The downside is more space cost and extra padding at the end of allocated user space which reduces the effectiveness if overrun happens only in the padded bytes. 